### PR TITLE
Add CI using Github actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,10 +18,6 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2
 
-      - name: Install command dependencies
-        run: |
-          echo "::set-env name=GO_VERSION::$(go version | awk '{ print $3}' | sed 's/^go//')"
-
       - name: Lint
         run: make lint
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,7 +3,7 @@ on:
   pull_request:
   push:
     branches:
-      - master
+      - main
 jobs:
   build-linux:
     name: Build

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,36 @@
+name: build
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+jobs:
+  build-linux:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go 1.15
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.15
+        id: go
+
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Install command dependencies
+        run: |
+          echo "::set-env name=GO_VERSION::$(go version | awk '{ print $3}' | sed 's/^go//')"
+
+      - name: Lint
+        run: make lint
+
+      - name: Build
+        run: make build-client
+
+      - name: Release(test)
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          args: release --snapshot --skip-publish --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,4 +22,4 @@ jobs:
         with:
           args: release --rm-dist
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_ACCESS_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,25 @@
+name: release
+on:
+  push:
+    branches:
+      - "!*"
+    tags:
+      - "v*.*.*"
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: release
+    steps:
+      - name: Set up Go 1.15
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.15
+        id: go
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+      - name: Release via goreleaser
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_ACCESS_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,29 @@
+builds:
+  - id: k3ai-client
+    binary: k3ai-client
+    main: ./
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+archives:
+  - format: tar.gz
+    format_overrides:
+      - goos: windows
+        format: zip
+snapshot:
+  name_template: "{{.Version}}-next"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "README.md"
+      - ".gitignore"
+      - "^site:"
+      - "^examples:"
+      - Merge pull request
+      - Merge branch

--- a/Makefile
+++ b/Makefile
@@ -7,3 +7,18 @@ endif
 
 build-client:
 	go build -o bin/k3ai-client
+
+.PHONY: lint
+lint: check-format
+	go vet ./...
+	# Add addiotional linters here
+
+.PHONY: check-format
+check-format:
+	@echo "Running gofmt..."
+	$(eval unformatted=$(shell find . -name '*.go' | grep -v ./.git | grep -v vendor | xargs gofmt -l))
+	$(if $(strip $(unformatted)),\
+		$(error $(\n) Some files are ill formatted! Run: \
+			$(foreach file,$(unformatted),$(\n)    gofmt -w $(file))$(\n)),\
+		@echo All files are well formatted.\
+	)

--- a/pkg/plugins/manage.go
+++ b/pkg/plugins/manage.go
@@ -60,7 +60,7 @@ func GetPluginList() (*GithubContents, error) {
 func GetPluginYamls(pluginName string) (*PluginSpecs, error) {
 	var yList PluginSpecs
 
-    githubContents, _ := GetPluginsFiltered(pluginName, FileType)
+	githubContents, _ := GetPluginsFiltered(pluginName, FileType)
 	for _, githubContent := range *githubContents {
 		var pluginSpec PluginSpec
 		pluginSpec.Encode(githubContent.Path)


### PR DESCRIPTION
The following changes have been made in this PR
1. Add a lint step to the Makefile that checks for unformatted files and performs a go vet
2. Adds CI for Pull requests. 
- This can evolve as the project grows. See: https://github.com/harsimranmaan/k3ai-core/pull/2/checks for preivew
3. Adds a release step when new tags are created.
- In order to cut a release: Create a new tag on the repo in the format vX.Y.Z.  [goreleaser](https://goreleaser.com/) would generate binaries for linux, darwin and windows. this can also be expanded in the future to generate deb, rpm, snap packages, docker images etc. A sample release can be found https://github.com/harsimranmaan/k3ai-core/releases/tag/v0.0.1. The release package would include the README.md, the binary and the LICENCE file by default.