### PR TITLE
Set version info during build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,8 +18,13 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2
 
+      - name: Prepare env
+        run: echo "GO_VERSION=(go version | awk '{ print $3}' | sed 's/^go//')" >> $GITHUB_ENV
+
       - name: Lint
-        run: make lint
+        run: |
+          echo $GO_VERSION
+          make lint
 
       - name: Test
         run: make test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Prepare env
-        run: echo "GO_VERSION=(go version | awk '{ print $3}' | sed 's/^go//')" >> $GITHUB_ENV
+        run: echo "GO_VERSION=$(go version | awk '{ print $3}' | sed 's/^go//')" >> $GITHUB_ENV
 
       - name: Lint
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,9 +22,7 @@ jobs:
         run: echo "GO_VERSION=$(go version | awk '{ print $3}' | sed 's/^go//')" >> $GITHUB_ENV
 
       - name: Lint
-        run: |
-          echo $GO_VERSION
-          make lint
+        run: make lint
 
       - name: Test
         run: make test

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,6 +17,8 @@ jobs:
         id: go
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
+      - name: Prepare env
+        run: echo "GO_VERSION=$(go version | awk '{ print $3}' | sed 's/^go//')" >> $GITHUB_ENV
       - name: Test
         run: make test
       - name: Release via goreleaser

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -3,7 +3,7 @@ builds:
     binary: k3ai-cli
     main: ./
     ldflags:
-      - -X github.com/kf5i/k3ai-core/cmd/tools/cli.version={{.Version}} -X github.com/kf5i/k3ai-core/cmd/tools/cli={{.Commit}} -X github.com/kf5i/k3ai-core/cmd/tools/cli.goVersion={{.Env.GO_VERSION}}
+      - -X github.com/kf5i/k3ai-core/cmd/tools/cli.version={{.Version}} -X github.com/kf5i/k3ai-core/cmd/tools/cli.commit={{.Commit}} -X github.com/kf5i/k3ai-core/cmd/tools/cli.goVersion={{.Env.GO_VERSION}}
     env:
       - CGO_ENABLED=0
     goos:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -2,6 +2,8 @@ builds:
   - id: k3ai-cli
     binary: k3ai-cli
     main: ./
+    ldflags:
+      - -X github.com/kf5i/k3ai-core/cmd/tools/cli.version={{.Version}} -X github.com/kf5i/k3ai-core/cmd/tools/cli={{.Commit}} -X github.com/kf5i/k3ai-core/cmd/tools/cli.goVersion={{.Env.GO_VERSION}}
     env:
       - CGO_ENABLED=0
     goos:

--- a/cmd/tools/cli/version.go
+++ b/cmd/tools/cli/version.go
@@ -7,6 +7,7 @@ import (
 )
 
 // These values are overridden at build time.
+// Please update ldflags aptly when renaming these vars or moving packages
 var (
 	version   = "dev"
 	commit    = "dev"


### PR DESCRIPTION
Example output
```bash
$ k3ai-cli version
k3ai-cli version: 0.0.3
go version: 1.15.3
commit: 89b606216fa54f19600e7e579d8e65b04c65caac
```

https://github.com/harsimranmaan/k3ai-core/releases/tag/v0.0.3 as an example