### PR TITLE
Hide usage info for cmd errors

### DIFF
--- a/cmd/tools/cli/cli.go
+++ b/cmd/tools/cli/cli.go
@@ -19,6 +19,8 @@ var rootCmd = &cobra.Command{
 	Long: fmt.Sprintf(` %s is a lightweight infrastructure-in-a-box solution specifically built to
 	install and configure AI tools and platforms in production environments on Edge
 	and IoT devices as easily as local test environments.`, k3aiBinaryName),
+	SilenceUsage:  true,
+	SilenceErrors: true,
 }
 
 var pluginRepoUri string

--- a/internal/k8s/kctl/deploy.go
+++ b/internal/k8s/kctl/deploy.go
@@ -64,5 +64,3 @@ func execute(config Config, command string, args ...string) error {
 	cmd.Stderr = config.Stderr()
 	return cmd.Run()
 }
-
-////// Name Spaces


### PR DESCRIPTION
Closes #20

```bash
$ go run main.go list --plugin-repo=https://non
cannot load plugins: Get "https://non": dial tcp: lookup non: no such host
exit status 1
```