### PR TITLE
Add ability to use kubectl directly

### DIFF
--- a/cmd/tools/cli/cli.go
+++ b/cmd/tools/cli/cli.go
@@ -25,12 +25,12 @@ var rootCmd = &cobra.Command{
 
 var (
 	pluginRepoURI string
-	useK3s        bool
+	useKubectl    bool
 )
 
 func init() {
 	rootCmd.PersistentFlags().StringVarP(&pluginRepoURI, "plugin-repo", "", plugins.DefaultPluginURI, "URI for the plugins repository. Must begin with https:// or file://")
-	rootCmd.PersistentFlags().BoolVarP(&useK3s, "k3s", "", true, "Use k3s for deployment. Uses kubectl when set to false")
+	rootCmd.PersistentFlags().BoolVarP(&useKubectl, "kubectl", "", false, "Use kubectl for deployment. Uses k3s when set to false")
 	rootCmd.AddCommand(versionCmd)
 	rootCmd.AddCommand(applyCmd)
 	rootCmd.AddCommand(deleteCmd)
@@ -47,17 +47,17 @@ func Execute() {
 
 type config struct {
 	context.Context
-	stdin  io.Reader // standard input
-	stdout io.Writer // standard output
-	stderr io.Writer // standard error
-	useK3s bool
+	stdin      io.Reader // standard input
+	stdout     io.Writer // standard output
+	stderr     io.Writer // standard error
+	useKubectl bool
 }
 
 func newConfig() kctl.Config {
 	return &config{
 		context.Background(),
 		os.Stdin, os.Stdout, os.Stderr,
-		useK3s,
+		useKubectl,
 	}
 }
 
@@ -71,6 +71,6 @@ func (c *config) Stderr() io.Writer {
 	return c.stderr
 }
 
-func (c *config) UseK3s() bool {
-	return c.useK3s
+func (c *config) UseKubectl() bool {
+	return c.useKubectl
 }

--- a/cmd/tools/cli/cli.go
+++ b/cmd/tools/cli/cli.go
@@ -23,10 +23,14 @@ var rootCmd = &cobra.Command{
 	SilenceErrors: true,
 }
 
-var pluginRepoURI string
+var (
+	pluginRepoURI string
+	useK3s        bool
+)
 
 func init() {
 	rootCmd.PersistentFlags().StringVarP(&pluginRepoURI, "plugin-repo", "", plugins.DefaultPluginURI, "URI for the plugins repository. Must begin with https:// or file://")
+	rootCmd.PersistentFlags().BoolVarP(&useK3s, "k3s", "", true, "Use k3s for deployment. Uses kubectl when set to false")
 	rootCmd.AddCommand(versionCmd)
 	rootCmd.AddCommand(applyCmd)
 	rootCmd.AddCommand(deleteCmd)
@@ -46,12 +50,14 @@ type config struct {
 	stdin  io.Reader // standard input
 	stdout io.Writer // standard output
 	stderr io.Writer // standard error
+	useK3s bool
 }
 
 func newConfig() kctl.Config {
 	return &config{
 		context.Background(),
 		os.Stdin, os.Stdout, os.Stderr,
+		useK3s,
 	}
 }
 
@@ -63,4 +69,8 @@ func (c *config) Stdout() io.Writer {
 }
 func (c *config) Stderr() io.Writer {
 	return c.stderr
+}
+
+func (c *config) UseK3s() bool {
+	return c.useK3s
 }

--- a/internal/k8s/kctl/config.go
+++ b/internal/k8s/kctl/config.go
@@ -9,4 +9,5 @@ type Config interface {
 	Stdin() io.Reader  // standard input
 	Stdout() io.Writer // standard output
 	Stderr() io.Writer // standard error
+	UseK3s() bool
 }

--- a/internal/k8s/kctl/config.go
+++ b/internal/k8s/kctl/config.go
@@ -9,5 +9,5 @@ type Config interface {
 	Stdin() io.Reader  // standard input
 	Stdout() io.Writer // standard output
 	Stderr() io.Writer // standard error
-	UseK3s() bool
+	UseKubectl() bool
 }

--- a/internal/k8s/kctl/deploy.go
+++ b/internal/k8s/kctl/deploy.go
@@ -71,7 +71,7 @@ func execute(config Config, command string, args ...string) error {
 
 func prepareCommand(config Config, args ...string) (string, []string) {
 	command := kubectl
-	if config.UseKubectl() {
+	if !config.UseKubectl() {
 		command = k3sExec
 		args = append([]string{kubectl}, args...)
 	}

--- a/internal/k8s/kctl/deploy.go
+++ b/internal/k8s/kctl/deploy.go
@@ -71,7 +71,7 @@ func execute(config Config, command string, args ...string) error {
 
 func prepareCommand(config Config, args ...string) (string, []string) {
 	command := kubectl
-	if config.UseK3s() {
+	if config.UseKubectl() {
 		command = k3sExec
 		args = append([]string{kubectl}, args...)
 	}

--- a/internal/k8s/kctl/deploy.go
+++ b/internal/k8s/kctl/deploy.go
@@ -48,8 +48,9 @@ func handleYaml(config Config, command string, plugin plugins.PluginSpec) error 
 		if command == apply {
 			_ = createNameSpace(config, yamlSpec.NameSpace)
 		}
-		err := execute(config, k3sExec, kubectl, command,
+		command, args := prepareCommand(config, command,
 			decodeType(yamlSpec.Type), yamlSpec.URL, "-n", yamlSpec.NameSpace)
+		err := execute(config, command, args...)
 		if err != nil {
 			return err
 		}
@@ -66,4 +67,13 @@ func execute(config Config, command string, args ...string) error {
 	cmd.Stdout = config.Stdout()
 	cmd.Stderr = config.Stderr()
 	return cmd.Run()
+}
+
+func prepareCommand(config Config, args ...string) (string, []string) {
+	command := kubectl
+	if config.UseK3s() {
+		command = k3sExec
+		args = append([]string{kubectl}, args...)
+	}
+	return command, args
 }


### PR DESCRIPTION
Closes #21
Now that we have this, it should be possible to add integration tests against something like kind