### PR TITLE
Add inline plugins for the groups

### DIFF
--- a/cmd/tools/cli/apply.go
+++ b/cmd/tools/cli/apply.go
@@ -42,6 +42,14 @@ func applyGroup(config kctl.Config, groupName string) error {
 				}
 			}
 		}
+
+		for _, inlinePlugin := range group.InlinePlugins {
+			err = kctl.Apply(config, inlinePlugin, nil)
+			if err != nil {
+				return err
+			}
+		}
+
 	}
 
 	return nil

--- a/cmd/tools/cli/delete.go
+++ b/cmd/tools/cli/delete.go
@@ -43,6 +43,13 @@ func deleteGroup(config kctl.Config, groupName string) error {
 				}
 			}
 		}
+
+		for _, inlinePlugin := range group.InlinePlugins {
+			err = kctl.Delete(config, inlinePlugin)
+			if err != nil {
+				return err
+			}
+		}
 	}
 	return nil
 }

--- a/cmd/tools/cli/integration_test.go
+++ b/cmd/tools/cli/integration_test.go
@@ -67,7 +67,7 @@ func TestLocalDelete(t *testing.T) {
 
 func TestLocalGroupApply(t *testing.T) {
 	cmd, out := setUp()
-	cmd.SetArgs([]string{"apply", "-g", "argo", "--kubectl", "--group-repo", joinWithRootData("groups")})
+	cmd.SetArgs([]string{"apply", "-g", "argo-workflow", "--kubectl", "--group-repo", joinWithRootData("groups")})
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("unexpected error %v", err)
 	}
@@ -76,7 +76,7 @@ func TestLocalGroupApply(t *testing.T) {
 
 func TestLocalGroupDelete(t *testing.T) {
 	cmd, out := setUp()
-	cmd.SetArgs([]string{"delete", "-g", "argo", "--kubectl", "--group-repo", joinWithRootData("groups")})
+	cmd.SetArgs([]string{"delete", "-g", "argo-workflow", "--kubectl", "--group-repo", joinWithRootData("groups")})
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("unexpected error %v", err)
 	}

--- a/internal/plugins/groups.go
+++ b/internal/plugins/groups.go
@@ -14,9 +14,10 @@ type PluginGroup struct {
 
 //Group is the specification of each k3ai plugins group
 type Group struct {
-	PluginType string        `yaml:"plugin-type"`
-	GroupName  string        `yaml:"group-name"`
-	Plugins    []PluginGroup `yaml:"plugins,flow"`
+	PluginType    string        `yaml:"plugin-type"`
+	GroupName     string        `yaml:"group-name"`
+	Plugins       []PluginGroup `yaml:"plugins,flow"`
+	InlinePlugins []Plugin      `yaml:"inline-plugins,flow"`
 }
 
 //Groups is the specification of each k3ai plugins group

--- a/internal/plugins/groups_test.go
+++ b/internal/plugins/groups_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestValidatePluginsGroupSpec(t *testing.T) {
 	var group Group
-	testPluginsGroupsSpec, err := group.Encode(joinWithRootData("groups/argo/group.yaml"))
+	testPluginsGroupsSpec, err := group.Encode(joinWithRootData("groups/argo-workflow/group.yaml"))
 
 	if err != nil {
 		t.Fatalf("failed to unmarshal test file: %s", err)

--- a/internal/plugins/remote_contents_test.go
+++ b/internal/plugins/remote_contents_test.go
@@ -55,7 +55,7 @@ func TestPluginYamls(t *testing.T) {
 }
 
 func TestGroupsYamls(t *testing.T) {
-	var server = mockPluginsServer(t, joinWithRootData("groups/argo/group.yaml"), GroupType)
+	var server = mockPluginsServer(t, joinWithRootData("groups/argo-workflow/group.yaml"), GroupType)
 	defer server.Close()
 	var groups Groups
 	r, err := groups.Encode(server.URL, "/test")

--- a/local_repo/core/groups/argo-workflow/group.yaml
+++ b/local_repo/core/groups/argo-workflow/group.yaml
@@ -1,0 +1,11 @@
+plugin-type: group
+group-name: argo-workflow
+plugins:
+  - name: test
+    enabled: false
+  - name: argo-workflow
+    enabled: true
+inline-plugins:
+  - plugin-name: Argo-bind-traefik
+    yaml:
+      - url: "https://raw.githubusercontent.com/kf5i/k3ai-plugins/main/common/traefik/argo-bind.yaml"

--- a/local_repo/core/groups/argo/group.yaml
+++ b/local_repo/core/groups/argo/group.yaml
@@ -1,5 +1,0 @@
-plugin-type: group
-group-name: only-argo
-plugins:
-  - name: argo
-    enabled: true


### PR DESCRIPTION
So we can mix existing groups with the inline definition.

It is useful to create plugins for specific situations, for example, I want to add the traefik binding for `arg-workflow` plugin.
so it is:

```yaml
plugin-type: group
group-name: argo-workflow-binding
plugins:
   - name: argo-workflow  # <<--- here it uses the official plugin
    enabled: true
inline-plugins:
  - plugin-name: Argo-bind-traefik  # <<--- here It defines a plugin only for this specific case.
    yaml:
      - url: "https://raw.githubusercontent.com/kf5i/k3ai-plugins/main/common/traefik/argo-bind.yaml"
```
 
Don't merge yet, I'd like to merge https://github.com/kf5i/k3ai-core/pull/51 before
