### PR TITLE
Make use of kubectl as main command

### DIFF
--- a/cmd/tools/cli/cli.go
+++ b/cmd/tools/cli/cli.go
@@ -25,7 +25,6 @@ var rootCmd = &cobra.Command{
 
 var (
 	repo       string
-	useKubectl bool
 )
 
 func init() {
@@ -39,7 +38,6 @@ func setupCli(baseCmd *cobra.Command) {
 	}
 
 	baseCmd.PersistentFlags().StringVarP(&repo, "repo", "", s.Repo, "URI for the plugins repository. ")
-	baseCmd.PersistentFlags().BoolVarP(&useKubectl, "kubectl", "", s.UseKubectl, "Use kubectl for deployment. Uses k3s when set to false")
 	baseCmd.AddCommand(versionCmd)
 	baseCmd.AddCommand(newApplyCommand())
 
@@ -60,14 +58,12 @@ type config struct {
 	stdin      io.Reader // standard input
 	stdout     io.Writer // standard output
 	stderr     io.Writer // standard error
-	useKubectl bool
 }
 
 func newConfig(cmd *cobra.Command) kctl.Config {
 	return &config{
 		context.Background(),
 		cmd.InOrStdin(), cmd.OutOrStdout(), cmd.ErrOrStderr(),
-		useKubectl,
 	}
 }
 
@@ -79,8 +75,4 @@ func (c *config) Stdout() io.Writer {
 }
 func (c *config) Stderr() io.Writer {
 	return c.stderr
-}
-
-func (c *config) UseKubectl() bool {
-	return c.useKubectl
 }

--- a/cmd/tools/cli/cli.go
+++ b/cmd/tools/cli/cli.go
@@ -24,7 +24,7 @@ var rootCmd = &cobra.Command{
 }
 
 var (
-	repo       string
+	repo string
 )
 
 func init() {
@@ -55,9 +55,9 @@ func Execute() {
 
 type config struct {
 	context.Context
-	stdin      io.Reader // standard input
-	stdout     io.Writer // standard output
-	stderr     io.Writer // standard error
+	stdin  io.Reader // standard input
+	stdout io.Writer // standard output
+	stderr io.Writer // standard error
 }
 
 func newConfig(cmd *cobra.Command) kctl.Config {

--- a/cmd/tools/cli/integration_test.go
+++ b/cmd/tools/cli/integration_test.go
@@ -24,7 +24,7 @@ func setUp() (*cobra.Command, *bytes.Buffer) {
 }
 func TestApply(t *testing.T) {
 	cmd, out := setUp()
-	cmd.SetArgs([]string{"apply", "--kubectl", "ci-tests"})
+	cmd.SetArgs([]string{"apply", "ci-tests"})
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("unexpected error %v", err)
 	}
@@ -40,7 +40,7 @@ func TestDelete(t *testing.T) {
 	cmd, out := setUp()
 	cmd.SetOut(out)
 	cmd.SetErr(out)
-	cmd.SetArgs([]string{"delete", "--kubectl", "ci-tests"})
+	cmd.SetArgs([]string{"delete", "ci-tests"})
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("unexpected error %v", err)
 	}
@@ -49,7 +49,7 @@ func TestDelete(t *testing.T) {
 
 func TestLocalApply(t *testing.T) {
 	cmd, out := setUp()
-	cmd.SetArgs([]string{"apply", "argo-workflow-ns", "--kubectl", "--repo", joinWithRootData()})
+	cmd.SetArgs([]string{"apply", "argo-workflow-ns", "--repo", joinWithRootData()})
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("unexpected error %v", err)
 	}
@@ -58,7 +58,7 @@ func TestLocalApply(t *testing.T) {
 
 func TestLocalDelete(t *testing.T) {
 	cmd, out := setUp()
-	cmd.SetArgs([]string{"delete", "argo-workflow-ns", "--kubectl", "--repo", joinWithRootData()})
+	cmd.SetArgs([]string{"delete", "argo-workflow-ns", "--repo", joinWithRootData()})
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("unexpected error %v", err)
 	}
@@ -67,7 +67,7 @@ func TestLocalDelete(t *testing.T) {
 
 func TestLocalGroupApply(t *testing.T) {
 	cmd, out := setUp()
-	cmd.SetArgs([]string{"apply", "-g", "argo-workflow", "--kubectl", "--repo", joinWithRootData()})
+	cmd.SetArgs([]string{"apply", "-g", "argo-workflow", "--repo", joinWithRootData()})
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("unexpected error %v", err)
 	}
@@ -76,7 +76,7 @@ func TestLocalGroupApply(t *testing.T) {
 
 func TestLocalGroupDelete(t *testing.T) {
 	cmd, out := setUp()
-	cmd.SetArgs([]string{"delete", "-g", "argo-workflow", "--kubectl", "--repo", joinWithRootData()})
+	cmd.SetArgs([]string{"delete", "-g", "argo-workflow", "--repo", joinWithRootData()})
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("unexpected error %v", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.1.1
 	golang.org/x/crypto v0.0.0-20201016220609-9e8e0b390897 // indirect
+	golang.org/x/lint v0.0.0-20201208152925-83fdc39ff7b5 // indirect
 	golang.org/x/net v0.0.0-20201016165138-7b1cca2348c0 // indirect
 	golang.org/x/sys v0.0.0-20201018121011-98379d014ca7 // indirect
 	golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e // indirect

--- a/go.sum
+++ b/go.sum
@@ -430,6 +430,8 @@ golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f/go.mod h1:5qLYkcX4OjUUV8bRu
 golang.org/x/lint v0.0.0-20200130185559-910be7a94367/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/lint v0.0.0-20200302205851-738671d3881b h1:Wh+f8QHJXR411sJR8/vRBTZ7YapZaRvUcLFFJhusH0k=
 golang.org/x/lint v0.0.0-20200302205851-738671d3881b/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
+golang.org/x/lint v0.0.0-20201208152925-83fdc39ff7b5 h1:2M3HP5CCK1Si9FQhwnzYhXdG6DXeebvUHFpre8QvbyI=
+golang.org/x/lint v0.0.0-20201208152925-83fdc39ff7b5/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/mobile v0.0.0-20190312151609-d3739f865fa6/go.mod h1:z+o9i4GpDbdi3rU15maQ/Ox0txvL9dWGYEHz965HBQE=
 golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028/go.mod h1:E/iHnbuqvinMTCcRqshq8CkpyQDoeVncDDYHnLhea+o=
 golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKGUJ2LatrhH/nqhxcFungHvyanc=

--- a/go.sum
+++ b/go.sum
@@ -255,6 +255,7 @@ github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.11 h1:3tnifQM4i+fbajXKBHXWEH+KvNHqojZ778UH75j3bGA=
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
+github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=

--- a/internal/k8s/kctl/config.go
+++ b/internal/k8s/kctl/config.go
@@ -9,5 +9,4 @@ type Config interface {
 	Stdin() io.Reader  // standard input
 	Stdout() io.Writer // standard output
 	Stderr() io.Writer // standard error
-	UseKubectl() bool
 }

--- a/internal/k8s/kctl/deploy.go
+++ b/internal/k8s/kctl/deploy.go
@@ -9,7 +9,6 @@ import (
 )
 
 const (
-	k3sExec = "k3s"
 	kubectl = "kubectl"
 	apply   = "apply"
 	delete  = "delete"
@@ -84,9 +83,5 @@ func execute(config Config, command string, args ...string) error {
 
 func prepareCommand(config Config, args ...string) (string, []string) {
 	command := kubectl
-	if !config.UseKubectl() {
-		command = k3sExec
-		args = append([]string{kubectl}, args...)
-	}
 	return command, args
 }


### PR DESCRIPTION
With this PR I've removed the reference to K3s as the main command so users fully use `kubectl ` as the only underline command to interact with the various K8's instances.

**Why I did this:**
 `kubectl ` is covering more use cases than k3s itself, since now we do support also KinD and K0s within k3ai it makes easier for users that do not need anymore to pass the `--kubectl` switch

**What is still missing**
In the init I'm planning to add a way to download the  `kubectl ` binary, currently, it only references the URL to download it. This will make life easier for users as well.