### PR TITLE
Helm Support

### DIFF
--- a/internal/k8s/kctl/deploy.go
+++ b/internal/k8s/kctl/deploy.go
@@ -116,14 +116,13 @@ func execute(config Config, command string, args ...string) error {
 			cmd.Stdout = config.Stdout()
 			cmd.Stderr = config.Stderr()
 			return cmd.Run()
-		} else {
-			installCmd = append(installCmd, strings.Split(args[1], " ")...)
-			cmd := exec.Command(command, installCmd...)
-			log.Print(cmd)
-			cmd.Stdout = config.Stdout()
-			cmd.Stderr = config.Stderr()
-			return cmd.Run()
 		}
+		installCmd = append(installCmd, strings.Split(args[1], " ")...)
+		cmd := exec.Command(command, installCmd...)
+		log.Print(cmd)
+		cmd.Stdout = config.Stdout()
+		cmd.Stderr = config.Stderr()
+		return cmd.Run()
 	}
 	cmd := exec.Command(command, args...)
 	cmd.Stdout = config.Stdout()

--- a/internal/k8s/kctl/deploy.go
+++ b/internal/k8s/kctl/deploy.go
@@ -3,6 +3,7 @@ package kctl
 import (
 	"log"
 	"os/exec"
+	"strings"
 	"time"
 
 	"github.com/kf5i/k3ai-core/internal/plugins"
@@ -10,9 +11,12 @@ import (
 
 const (
 	kubectl = "kubectl"
+	helm = "helm"
 	apply   = "apply"
 	delete  = "delete"
 	create  = "create"
+	helmApply   = "install"
+	helmDelete  = "delete"
 )
 
 func pause() {
@@ -24,9 +28,21 @@ func Apply(config Config, plugin plugins.Plugin, evt Wait) error {
 	_ = createNameSpace(config, plugin.Namespace)
 	pause()
 	for _, yamlSpec := range plugin.Yaml {
-		command, args := prepareCommand(config, apply,
-			decodeType(yamlSpec.Type), yamlSpec.URL, "-n", plugin.Namespace)
-		err := execute(config, command, args...)
+		var err error
+		if decodeType(yamlSpec.Type) == "helm" {
+			command, args := prepareCommand(config, helm, helmApply,
+				yamlSpec.URL)
+			err = execute(config,command, args...)
+		} else if decodeType(yamlSpec.Type) == "container" {
+			command, args := prepareCommand(config, apply,
+				decodeType(yamlSpec.Type), yamlSpec.URL, "-n", plugin.Namespace)
+			err = execute(config, command, args...)
+		}else {
+			command, args := prepareCommand(config, apply,
+				decodeType(yamlSpec.Type), yamlSpec.URL, "-n", plugin.Namespace)
+			err = execute(config, command, args...)
+		}
+
 		if err != nil {
 			log.Printf("Error during create: %s\n", err.Error())
 		}
@@ -52,11 +68,20 @@ func Apply(config Config, plugin plugins.Plugin, evt Wait) error {
 
 // Delete removes the plugin from the cluster
 func Delete(config Config, plugin plugins.Plugin) error {
+	var err error
 	for i := len(plugin.Yaml) - 1; i >= 0; i-- {
 		yamlSpec := plugin.Yaml[i]
-		command, args := prepareCommand(config, delete,
-			decodeType(yamlSpec.Type), yamlSpec.URL, "-n", plugin.Namespace)
-		err := execute(config, command, args...)
+		if decodeType(yamlSpec.Type) == "helm"{
+			command, args := prepareCommand(config, helm, helmDelete,
+				yamlSpec.URL, "--namespace", plugin.Namespace)
+			err = execute(config,command, args...)
+		}else if decodeType(yamlSpec.Type) == "container"{
+
+		}else {
+			command, args := prepareCommand(config, delete,
+				decodeType(yamlSpec.Type), yamlSpec.URL, "-n", plugin.Namespace)
+			err = execute(config, command, args...)
+		}
 		if err != nil {
 			log.Printf("Error during delete: %s\n", err.Error())
 
@@ -71,10 +96,35 @@ func decodeType(commandType string) string {
 	if commandType == plugins.CommandKustomize {
 		return "-k"
 	}
+	if commandType == plugins.CommandHelm {
+		return "helm"
+	}
 	return "-f"
 }
 
 func execute(config Config, command string, args ...string) error {
+	if command == helm {
+		var installCmd []string
+		copy(args[0:], args[0+1:]) // Shift a[i+1:] left one index.
+		args[len(args)-1] = "" 
+		args = args[:len(args)-1]
+		installCmd = append(installCmd,args[0])
+		if args[0] == "delete" {
+			installCmd = append(installCmd,strings.Split(args[1]," ")...)
+			cmd := exec.Command(command,installCmd[0],installCmd[1], args[2], args[3])
+			log.Print(cmd)
+			cmd.Stdout = config.Stdout()
+			cmd.Stderr = config.Stderr()
+			return cmd.Run()
+		}else {
+			installCmd = append(installCmd,strings.Split(args[1]," ")...)
+			cmd := exec.Command(command,installCmd...)
+			log.Print(cmd)
+			cmd.Stdout = config.Stdout()
+			cmd.Stderr = config.Stderr()
+			return cmd.Run()
+		}
+	}
 	cmd := exec.Command(command, args...)
 	cmd.Stdout = config.Stdout()
 	cmd.Stderr = config.Stderr()
@@ -82,6 +132,10 @@ func execute(config Config, command string, args ...string) error {
 }
 
 func prepareCommand(config Config, args ...string) (string, []string) {
+	if args[0] == helm {
+		command := helm
+		return command, args
+	}
 	command := kubectl
 	return command, args
 }

--- a/internal/k8s/kctl/deploy.go
+++ b/internal/k8s/kctl/deploy.go
@@ -10,13 +10,13 @@ import (
 )
 
 const (
-	kubectl = "kubectl"
-	helm = "helm"
-	apply   = "apply"
-	delete  = "delete"
-	create  = "create"
-	helmApply   = "install"
-	helmDelete  = "delete"
+	kubectl    = "kubectl"
+	helm       = "helm"
+	apply      = "apply"
+	delete     = "delete"
+	create     = "create"
+	helmApply  = "install"
+	helmDelete = "delete"
 )
 
 func pause() {
@@ -32,12 +32,12 @@ func Apply(config Config, plugin plugins.Plugin, evt Wait) error {
 		if decodeType(yamlSpec.Type) == "helm" {
 			command, args := prepareCommand(config, helm, helmApply,
 				yamlSpec.URL)
-			err = execute(config,command, args...)
+			err = execute(config, command, args...)
 		} else if decodeType(yamlSpec.Type) == "container" {
 			command, args := prepareCommand(config, apply,
 				decodeType(yamlSpec.Type), yamlSpec.URL, "-n", plugin.Namespace)
 			err = execute(config, command, args...)
-		}else {
+		} else {
 			command, args := prepareCommand(config, apply,
 				decodeType(yamlSpec.Type), yamlSpec.URL, "-n", plugin.Namespace)
 			err = execute(config, command, args...)
@@ -71,13 +71,13 @@ func Delete(config Config, plugin plugins.Plugin) error {
 	var err error
 	for i := len(plugin.Yaml) - 1; i >= 0; i-- {
 		yamlSpec := plugin.Yaml[i]
-		if decodeType(yamlSpec.Type) == "helm"{
+		if decodeType(yamlSpec.Type) == "helm" {
 			command, args := prepareCommand(config, helm, helmDelete,
 				yamlSpec.URL, "--namespace", plugin.Namespace)
-			err = execute(config,command, args...)
-		}else if decodeType(yamlSpec.Type) == "container"{
+			err = execute(config, command, args...)
+		} else if decodeType(yamlSpec.Type) == "container" {
 
-		}else {
+		} else {
 			command, args := prepareCommand(config, delete,
 				decodeType(yamlSpec.Type), yamlSpec.URL, "-n", plugin.Namespace)
 			err = execute(config, command, args...)
@@ -106,19 +106,19 @@ func execute(config Config, command string, args ...string) error {
 	if command == helm {
 		var installCmd []string
 		copy(args[0:], args[0+1:]) // Shift a[i+1:] left one index.
-		args[len(args)-1] = "" 
+		args[len(args)-1] = ""
 		args = args[:len(args)-1]
-		installCmd = append(installCmd,args[0])
+		installCmd = append(installCmd, args[0])
 		if args[0] == "delete" {
-			installCmd = append(installCmd,strings.Split(args[1]," ")...)
-			cmd := exec.Command(command,installCmd[0],installCmd[1], args[2], args[3])
+			installCmd = append(installCmd, strings.Split(args[1], " ")...)
+			cmd := exec.Command(command, installCmd[0], installCmd[1], args[2], args[3])
 			log.Print(cmd)
 			cmd.Stdout = config.Stdout()
 			cmd.Stderr = config.Stderr()
 			return cmd.Run()
-		}else {
-			installCmd = append(installCmd,strings.Split(args[1]," ")...)
-			cmd := exec.Command(command,installCmd...)
+		} else {
+			installCmd = append(installCmd, strings.Split(args[1], " ")...)
+			cmd := exec.Command(command, installCmd...)
 			log.Print(cmd)
 			cmd.Stdout = config.Stdout()
 			cmd.Stderr = config.Stderr()

--- a/internal/plugins/plugins.go
+++ b/internal/plugins/plugins.go
@@ -7,12 +7,12 @@ import (
 
 const (
 	commandFile = "file"
-	// commandKustomize is the kustomize command
-	commandKustomize = "kustomize"
+	// CommandKustomize is the kustomize command
+	CommandKustomize = "kustomize"
 	// commandHelm is the helm command
-	commandHelm = "helm"
+	CommandHelm = "helm"
 	// commandDocker is the container command
-	commandDocker = "container"
+	CommandDocker = "container"
 	// DefaultPluginFileName is the default plugin name
 	// each plugin must contain this file else it will be ignored
 	DefaultPluginFileName = "plugin.yaml"
@@ -84,8 +84,8 @@ func (ps *Plugin) validate() error {
 	}
 	for _, yamlType := range ps.Yaml {
 		// First let's check if we are in the need of using Kustomize or File
-		if yamlType.Type != commandKustomize && yamlType.Type != commandFile {
-			if yamlType.Type != commandHelm && yamlType.Type != commandDocker {
+		if yamlType.Type != CommandKustomize && yamlType.Type != commandFile {
+			if yamlType.Type != CommandHelm && yamlType.Type != CommandDocker {
 				return errors.New("type must be one of the supported ones. Please check the documentation.")
 			}
 		}

--- a/internal/plugins/plugins.go
+++ b/internal/plugins/plugins.go
@@ -9,9 +9,9 @@ const (
 	commandFile = "file"
 	// CommandKustomize is the kustomize command
 	CommandKustomize = "kustomize"
-	// commandHelm is the helm command
+	// CommandHelm is the helm command
 	CommandHelm = "helm"
-	// commandDocker is the container command
+	// CommandDocker is the container command
 	CommandDocker = "container"
 	// DefaultPluginFileName is the default plugin name
 	// each plugin must contain this file else it will be ignored
@@ -86,7 +86,7 @@ func (ps *Plugin) validate() error {
 		// First let's check if we are in the need of using Kustomize or File
 		if yamlType.Type != CommandKustomize && yamlType.Type != commandFile {
 			if yamlType.Type != CommandHelm && yamlType.Type != CommandDocker {
-				return errors.New("type must be one of the supported ones. Please check the documentation.")
+				return errors.New("type must be one of the supported ones. Please check the documentation")
 			}
 		}
 	}

--- a/internal/plugins/plugins.go
+++ b/internal/plugins/plugins.go
@@ -7,10 +7,12 @@ import (
 
 const (
 	commandFile = "file"
-	// CommandKustomize is the kustomize command
-	CommandKustomize = "kustomize"
-	CommandHelm      = "helm"
-	CommandDocker    = "container"
+	// commandKustomize is the kustomize command
+	commandKustomize = "kustomize"
+	// commandHelm is the helm command
+	commandHelm = "helm"
+	// commandDocker is the container command
+	commandDocker = "container"
 	// DefaultPluginFileName is the default plugin name
 	// each plugin must contain this file else it will be ignored
 	DefaultPluginFileName = "plugin.yaml"
@@ -82,8 +84,8 @@ func (ps *Plugin) validate() error {
 	}
 	for _, yamlType := range ps.Yaml {
 		// First let's check if we are in the need of using Kustomize or File
-		if yamlType.Type != CommandKustomize && yamlType.Type != commandFile {
-			if yamlType.Type != CommandHelm && yamlType.Type != CommandDocker {
+		if yamlType.Type != commandKustomize && yamlType.Type != commandFile {
+			if yamlType.Type != commandHelm && yamlType.Type != commandDocker {
 				return errors.New("type must be one of the supported ones. Please check the documentation.")
 			}
 		}

--- a/internal/plugins/plugins.go
+++ b/internal/plugins/plugins.go
@@ -9,8 +9,8 @@ const (
 	commandFile = "file"
 	// CommandKustomize is the kustomize command
 	CommandKustomize = "kustomize"
-	CommandHelm = "helm"
-	CommandDocker = "container"
+	CommandHelm      = "helm"
+	CommandDocker    = "container"
 	// DefaultPluginFileName is the default plugin name
 	// each plugin must contain this file else it will be ignored
 	DefaultPluginFileName = "plugin.yaml"

--- a/internal/plugins/plugins.go
+++ b/internal/plugins/plugins.go
@@ -9,6 +9,8 @@ const (
 	commandFile = "file"
 	// CommandKustomize is the kustomize command
 	CommandKustomize = "kustomize"
+	CommandHelm = "helm"
+	CommandDocker = "container"
 	// DefaultPluginFileName is the default plugin name
 	// each plugin must contain this file else it will be ignored
 	DefaultPluginFileName = "plugin.yaml"
@@ -30,13 +32,14 @@ type PostInstall struct {
 
 //Plugin is the specification of each k3ai plugin
 type Plugin struct {
-	Namespace         string      `yaml:"namespace,omitempty"`
-	Labels            []string    `yaml:",flow"`
 	PluginName        string      `yaml:"plugin-name"`
+	Labels            []string    `yaml:",flow"`
+	Namespace         string      `yaml:"namespace,omitempty"`
 	PluginDescription string      `yaml:"plugin-description"`
 	Yaml              []YamlType  `yaml:"yaml,flow"`
 	Bash              []string    `yaml:"bash,flow"`
 	Helm              []string    `yaml:"helm,flow"`
+	Container         []string    `yaml:"container,flow"`
 	PostInstall       PostInstall `yaml:"post-install"`
 }
 
@@ -78,8 +81,11 @@ func (ps *Plugin) validate() error {
 		return errors.New("namespace value must be 'default' or another value")
 	}
 	for _, yamlType := range ps.Yaml {
+		// First let's check if we are in the need of using Kustomize or File
 		if yamlType.Type != CommandKustomize && yamlType.Type != commandFile {
-			return errors.New("type must be file or kustomize")
+			if yamlType.Type != CommandHelm && yamlType.Type != CommandDocker {
+				return errors.New("type must be one of the supported ones. Please check the documentation.")
+			}
 		}
 	}
 	return nil


### PR DESCRIPTION
Added helm support
The structure of the plugins is the same as before.
**Note:** 
- For Helm is **not needed**  to add `helm install` after the`- url:` part.
- Currently, if the helm chart uses a dynamically generated name through the flag `--generated-name` is not possible to use the `k3ai delete`

```yaml
plugin-name: test
plugin-description: Test Plugin for new features
namespace: "seldon-system"
yaml:
  - url: "seldon-core seldon-core-operator \
    --repo https://storage.googleapis.com/seldon-charts \
    --set usageMetrics.enabled=true \
    --namespace seldon-system \
    --set istio.enabled=true"
    type: "helm"
```

Usage:
- *install*
`k3ai apply <helmplugin name>`
- *delete*
`k3ai delete <helmplugin name>`